### PR TITLE
Fix crash when sending message to user with dms disabled

### DIFF
--- a/src/helpers/messages.ts
+++ b/src/helpers/messages.ts
@@ -89,7 +89,7 @@ export const sendMatchFoundMessage = ({ client, match }: { client: Client; match
 
         if (!user) return;
         try {
-            user.send(`Your match was found, go ready in <#${readyChannel}>`);
+            await user.send(`Your match was found, go ready in <#${readyChannel}>`);
         } catch (error) {
             botLog({
                 messageContent: `Failed to send match found dm to <@${user.id}>`,


### PR DESCRIPTION
I have no idea how your bot doesn't crash, but the user.send call needs to be awaited in order for the try/catch statement to properly function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated `sendMatchFoundMessage` function for improved asynchronous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->